### PR TITLE
Bump firebase to 12 and @firebase/rules-unit-testing to 5, together

### DIFF
--- a/test_rules/README.md
+++ b/test_rules/README.md
@@ -9,6 +9,11 @@ Dart: `fake_cloud_firestore` supports neither custom functions nor
 npm ci && npm test     # needs JDK 21+ (firebase-tools 15)
 ```
 
+`@firebase/rules-unit-testing` and `firebase` must move together: v5 of the
+testing library declares a `firebase@^12` peer, so bumping either alone fails
+`npm ci` with `ERESOLVE`. Dependabot opens them as separate PRs and cannot know
+that — see #61.
+
 `flutter test` never sees this package, and CI runs it as its own job.
 
 ## Why `overrides` exists

--- a/test_rules/package-lock.json
+++ b/test_rules/package-lock.json
@@ -8,8 +8,8 @@
       "name": "flutter-template-rules-tests",
       "version": "1.0.0",
       "devDependencies": {
-        "@firebase/rules-unit-testing": "^4.0.1",
-        "firebase": "^11.0.0",
+        "@firebase/rules-unit-testing": "^5.0.2",
+        "firebase": "^12.0.0",
         "firebase-tools": "^15.28.2",
         "vitest": "^4.1.11"
       }
@@ -75,20 +75,20 @@
       }
     },
     "node_modules/@firebase/ai": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-1.4.1.tgz",
-      "integrity": "sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.15.0.tgz",
+      "integrity": "sha512-Aj7TbFdAIWZdkX8JfdDStERpR35g6WNs+7XhNPtFLFOizUotj6k4N/D8HJkR45165HhnMJBe4hjOeeaxnnn56Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -96,16 +96,16 @@
       }
     },
     "node_modules/@firebase/analytics": {
-      "version": "0.10.17",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.17.tgz",
-      "integrity": "sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg==",
+      "version": "0.10.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.24.tgz",
+      "integrity": "sha512-OfIAcIIwoqXjBzS+DnUQpOZ7i3ePaNFg83KPpDWjBZUKJmqMwzzAtLJqmKZOkQnW8im6vFR6f2I3M/9hxVd+QA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -113,142 +113,147 @@
       }
     },
     "node_modules/@firebase/analytics-compat": {
-      "version": "0.2.23",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.23.tgz",
-      "integrity": "sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw==",
+      "version": "0.2.30",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.30.tgz",
+      "integrity": "sha512-uVZEKlLaW4AHAhv8zoN9cTmveX6v86AVqcJ4LCaRCMTChTH8/NsjbisTq1lpBfWCLWS1spqwSHB4vol/YSCdMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/analytics": "0.10.17",
-        "@firebase/analytics-types": "0.8.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-types": "0.8.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/analytics-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
-      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.5.tgz",
+      "integrity": "sha512-kdnooE7Bis2jEnsqcerRwn/UQpH5D3uvHpku7OdUM9TJN3omlu6iYtbyAQ6XkAJRgJtO0aNf9OOkW8J6D59oCA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
-      "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.16.1.tgz",
+      "integrity": "sha512-tjUEorFyKrurH7PbLWv9zDHRuU4mLefgD/yY38D584ziorIRlQz/PVjx4c/SCGyCuUlmyzt72mK+Lh+COAywNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.10.1.tgz",
-      "integrity": "sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.13.1.tgz",
+      "integrity": "sha512-l8y3dmnhodXks/APAwx4tWqRl3tk8b9874KF1FJyKg1DIU+kMD0l52iz7S9/MW+eK8k6cjJg0G0iJ5KQAsQpow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.26.tgz",
-      "integrity": "sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.7.tgz",
+      "integrity": "sha512-fBb/xSMyIKv1nDmccfzz3IAGBzx/cQOxmZai66rJzifb1hMMkztf824Xx7LhpTUe7HNUbXwY90IvJ66fi8q6yg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check": "0.10.1",
-        "@firebase/app-check-types": "0.5.3",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-types": "0.5.5",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/app-check-interop-types": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
-      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.5.tgz",
+      "integrity": "sha512-qId34pVZ2CXTmtu4ofW5leiI93DvnOvIcr/5GT7MZPw5WXAi6nZoU+g9cNRgl7K90UJSbK0cXxten4meYMPyZg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-check-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
-      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.5.tgz",
+      "integrity": "sha512-+DF4gzFrlwGFyky38o4T/YN/r51l70yCtJ2HTkwmRj8FCMwPjm4hLH4fQbj6BUvzkiFqliBkitFsRpf1/YZkWA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
-      "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.17.tgz",
+      "integrity": "sha512-5GdJWobqs6jbNYOnaQiSa4Ng8gnFerhqr7nY+v5jlnT7o9QbEeIZRLPQpnLe0TxYSWfRV2lAMbyR0kbXeIos9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app": "0.13.2",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/app": "0.16.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
-      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@firebase/auth": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.10.8.tgz",
-      "integrity": "sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.6.tgz",
+      "integrity": "sha512-yPLahy7Esfu2w/yme3msVK4xTkDXQqq6szfQn8yVOQpCKiT5GVFjqNpLbuz6NkX0WuTwUidkmPewW3r4xkvpeg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/logger": "0.5.2"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.5.tgz",
+      "integrity": "sha512-1AXoBJqBVD8WL8FZYo3S2GmJF9YUoom6Y6ngMxOSkzzhW5sT83pLchb6TGFgxes91dfXx8s/VYc5VrLDNqpLog==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
-        "@react-native-async-storage/async-storage": "^1.18.1"
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
       },
       "peerDependenciesMeta": {
         "@react-native-async-storage/async-storage": {
@@ -257,36 +262,37 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.28.tgz",
-      "integrity": "sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.10.tgz",
+      "integrity": "sha512-Bvklg2nL7BrBFCAqdsleW8fse9Jh0fARqJPlJmA40uermfWx1bJiO7dnKyZN3J39d2TFVd4VJXtg3i6Wg92/YQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth": "1.10.8",
-        "@firebase/auth-types": "0.13.0",
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-types": "0.13.2",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
-      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.6.tgz",
+      "integrity": "sha512-FgwZqDrBqgK0BHI70QTv1v/5wmuDF9f8fsJFvKSxoRlK2PPfSQtZAk2jhXu4pe9BZzFi/e4UYusU/bEQHdf6Qg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-types": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
-      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.2.tgz",
+      "integrity": "sha512-OU+miuoSxIWYN7GT291d2ylVJBL3k/OePo7/JDSoQtkFQoEiGBc4AHuMjj/seqFIsHrqnjrAfRCk4pfufoJolQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -295,30 +301,30 @@
       }
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.18.tgz",
-      "integrity": "sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.5.tgz",
+      "integrity": "sha512-vuFDcL91Q+2ZuBJkyOh86T4q0B4ffNTDjc/A38tybO56odQABxRTFLTIowCWqAKeIcgo37GowWMVgFF73gD8Qw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.12.1",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/data-connect": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.10.tgz",
-      "integrity": "sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.4.tgz",
+      "integrity": "sha512-su1aGWlzhxb+xtggCUSsufJn1FDa06SBDK71y+fpQ+g2zMhMExik6FUv/odkKzOF/xfWVjabCbWBcjJY3MceDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -326,99 +332,113 @@
       }
     },
     "node_modules/@firebase/database": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.20.tgz",
-      "integrity": "sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.5.tgz",
+      "integrity": "sha512-/JGpvszLoNXNgzilRXocigGfFF4hbcPA9wN1i1kjJx6oKkXgkHteZYl3lQs1lJX3ETDf6bv7zI15lPMVUp4sAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.0.11.tgz",
-      "integrity": "sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.7.tgz",
+      "integrity": "sha512-lBq9sJm8MnJINKJnkAKSOj2MbC66xGoSVCcGkPtstl+lkoKEBtD46qHLbuDgW/WbLPoKVm17RIN8BxHj+Z2F2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/database": "1.0.20",
-        "@firebase/database-types": "1.0.15",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-types": "1.0.22",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-compat": "0.x"
+      },
+      "peerDependenciesMeta": {
+        "@firebase/app": {
+          "optional": true
+        },
+        "@firebase/app-compat": {
+          "optional": true
+        }
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.15.tgz",
-      "integrity": "sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.22.tgz",
+      "integrity": "sha512-YAZNXsjY9EQQ+pKw/3ax8n5FgolHC7Qew7EY5RceYdl0R2ZP+kCv1O0DkKlcceue8uQCOreHCNN7PWVFpY1Nug==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.3",
-        "@firebase/util": "1.12.1"
+        "@firebase/app-types": "0.9.6",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.8.0.tgz",
-      "integrity": "sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.17.1.tgz",
+      "integrity": "sha512-8lqPNf2w10CtYG+tayVjZO1pSyQpnhztQRudeD109VtXDzNbASTaYdO43sj5PMsDcWq0aOYY3RmJOUlXu9++jw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
-        "@firebase/webchannel-wrapper": "1.0.3",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
+        "@firebase/webchannel-wrapper": "1.0.7",
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
+        "re2js": "^2.8.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.53",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.53.tgz",
-      "integrity": "sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.13.tgz",
+      "integrity": "sha512-l9dCewxMzzLOIhcwTjERCKxrWOn1kZ9JvwOQq9zZNq4I/Nbvb/B9njT230V61uvQ9qZ3/qpUG758D8DDTEFXnw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/firestore": "4.8.0",
-        "@firebase/firestore-types": "3.0.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-types": "3.0.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/firestore-types": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
-      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.5.tgz",
+      "integrity": "sha512-dbdMAQkMd5dwWc48eupz/Y6/E9ruat3+gY5lhVKscvvT/HnDBEEMzJW38zdKhgdnglZHGk2vUsJMOHAphMHGMA==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -427,62 +447,63 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.12.9",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.12.9.tgz",
-      "integrity": "sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.14.0.tgz",
+      "integrity": "sha512-DhuYFr0eMhp+s/PNEk6SiMsYkc00+XVOUeKbrl8MOzQNZI3SKQpqoDR1d+keNDAutwmHRWTUAdXBoVPD+xxVUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-check-interop-types": "0.3.3",
-        "@firebase/auth-interop-types": "0.2.4",
-        "@firebase/component": "0.6.18",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/app-check-interop-types": "0.3.5",
+        "@firebase/auth-interop-types": "0.2.6",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.26",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.26.tgz",
-      "integrity": "sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.5.0.tgz",
+      "integrity": "sha512-T3BDIToESZUHt7438wyKYMkRjKg3m1xAIux5fVpNvTRQlDOFLukWniQWBDhJ2znpU9kxMTR6+e31TVo8P15PZw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/functions": "0.12.9",
-        "@firebase/functions-types": "0.6.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-types": "0.6.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/functions-types": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
-      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.5.tgz",
+      "integrity": "sha512-Zc0pURjthHXzSj54ZivCkzKDSV1r/wIpnmHdhq82q2yFFPVoncG/ZJjnVMiANvQfeww/QnElhzODpfwUucVwdA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/installations": {
-      "version": "0.6.18",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.18.tgz",
-      "integrity": "sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A==",
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.24.tgz",
+      "integrity": "sha512-Ui52ey8wHoWqkBbXRKJEKYWylI0JZogZmoLS+o8Anh1bxWtK27ZYjLla1UJAAdC5DCKLJ2qAp0VpJOjg8VOX1g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -491,26 +512,27 @@
       }
     },
     "node_modules/@firebase/installations-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.18.tgz",
-      "integrity": "sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.24.tgz",
+      "integrity": "sha512-8M5nlcWwYt881x83COP2odq5vgf+NgwJh+RMd4LRSv8JI1pxwDfgrDJOERrjTgfC9J5Z0vnQX4b1pdN914e0Zw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/installations-types": "0.5.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-types": "0.5.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/installations-types": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
-      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.5.tgz",
+      "integrity": "sha512-e9UYcju3puDl1vdrcKIi5dExzHLameOT/Tc61Q48PYwxtsM1NzZh/ikGbdBQTsbRgg0EMZqdPr0/m5ODUBobrg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -518,29 +540,29 @@
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.4.tgz",
-      "integrity": "sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.2.tgz",
+      "integrity": "sha512-J2VO4NFTc0xQFrxV1B/lm5balicm9cwuX2acR9Yn41fN8KgUeQFo+VJV222IqW2FPSXKDu9uo5WdQFWf9TPbYg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/messaging": {
-      "version": "0.12.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.22.tgz",
-      "integrity": "sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.2.tgz",
+      "integrity": "sha512-KcZoqUu2ih4sLH91dW9tmyHjCR0IQyNzSLZunX5uq7cLeImXb4uO2I0wq5FACduO2I+FoTeWa2BtUv7Jpowqdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/messaging-interop-types": "0.2.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/messaging-interop-types": "0.2.6",
+        "@firebase/util": "1.15.3",
         "idb": "7.1.1",
         "tslib": "^2.1.0"
       },
@@ -549,39 +571,40 @@
       }
     },
     "node_modules/@firebase/messaging-compat": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.22.tgz",
-      "integrity": "sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.29.tgz",
+      "integrity": "sha512-8Twe4CeYvAx8AzjBxyyQFKzinaMGGt13hPQBqaARQ2QZjagrEaqSVBe+Zy6F4L/vT8DV168yRgRu7W/RK7p+4w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/messaging": "0.12.22",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/messaging-interop-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
-      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.6.tgz",
+      "integrity": "sha512-MVzvkKe2V4H2dHu5oOxRfeKQcfTwWmCgnzsC4V1q3ixun5iiL8riCZ2qI35rDhCL4glPGiu0jHxDbpVNuTKfow==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/performance": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.7.tgz",
-      "integrity": "sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w==",
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.14.tgz",
+      "integrity": "sha512-9PH1XEZVHErxGdbXluvGz4Uyjw4W955H8v7Mv9rHIybRrg5F2Ac2tvf5+mSf5EtnxWNmxrD2WLnvMFaZP4sMrQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0",
         "web-vitals": "^4.2.4"
       },
@@ -590,41 +613,42 @@
       }
     },
     "node_modules/@firebase/performance-compat": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.20.tgz",
-      "integrity": "sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.27.tgz",
+      "integrity": "sha512-O/ozTf/EbChN94Pk7bd1eUC0PAC36726AwsaiJyC0bZzSBWfLGSWASGPH5pebUWXQPJtGxIJYRkkbX5l0Qa+Hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/performance": "0.7.7",
-        "@firebase/performance-types": "0.2.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-types": "0.2.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/performance-types": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
-      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.5.tgz",
+      "integrity": "sha512-PRzOgB+/M+6AKlEkY8a9xy5Ff5SfZPIh4iShXhn2WAcL/euSbK7bdLqWysHduunNJhGFsXa22Ag3ixqL6rQtYg==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/remote-config": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.6.5.tgz",
-      "integrity": "sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.2.tgz",
+      "integrity": "sha512-Rii93DkXjM+RE/ytHdYa7EIiQLJbdBr+W8EEiqd/vbLCOC+1FdkDuRiumJBp6t3yewHGbdqbpjB3fk3z0cZ+8g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/installations": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/installations": "0.6.24",
+        "@firebase/logger": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
@@ -632,85 +656,87 @@
       }
     },
     "node_modules/@firebase/remote-config-compat": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.18.tgz",
-      "integrity": "sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ==",
+      "version": "0.2.29",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.29.tgz",
+      "integrity": "sha512-mY7JtTISK6F4g4T0x3kVepr5cp0NXL7f5yjIUXXGaTrg4qUlFBWRbENaHaqZ78dwmNcLm24h/yPsOVRlDXEXhA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/logger": "0.4.4",
-        "@firebase/remote-config": "0.6.5",
-        "@firebase/remote-config-types": "0.4.0",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/logger": "0.5.2",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-types": "0.5.2",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/remote-config-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.4.0.tgz",
-      "integrity": "sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.2.tgz",
+      "integrity": "sha512-i8k1omVfoAnaT1ZPv2FFjxMZrATYsO/GnFgHEj5+7fAJLzi8wLnGGv1WK06oEAD6ltrWXSO1HzeNyajn/NjMWw==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/rules-unit-testing": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-4.0.1.tgz",
-      "integrity": "sha512-Vu8iMLP+dO9hCAqUCitWZQdORyM6CxucilRZtleeTZd5bejZmyOiaBPwYm3NOYG6025ac99CEeA+ETmJRxa9zg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-5.0.2.tgz",
+      "integrity": "sha512-g053AaFcuf4gpAQbwRK/GIIGfPHhpomW3qkIYLi4xnaTUrf65yGP+0TPdojoXfB/ejrfevkXmMs5qXOTSwdN6A==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "firebase": "^11.0.0"
+        "firebase": "^12.0.0"
       }
     },
     "node_modules/@firebase/storage": {
-      "version": "0.13.14",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.13.14.tgz",
-      "integrity": "sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g==",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.5.tgz",
+      "integrity": "sha512-r2tozN/BlEewLi70tJNUQPzWwbex9GM7NgXZsamHKQrjKEfcR0i4jGgHBKAKA4hbwiPE9eNMb3hcxWnDpeJZwg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.24",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.24.tgz",
-      "integrity": "sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.5.tgz",
+      "integrity": "sha512-vO0tFPxXbKDKdlTu8tYT08S9t9ezUTJYEdLCULpWxWq2aq6zojwN1QmAB+1a50AI/g47GlWUJn1XPncm/PDZsw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.18",
-        "@firebase/storage": "0.13.14",
-        "@firebase/storage-types": "0.8.3",
-        "@firebase/util": "1.12.1",
+        "@firebase/component": "0.7.5",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-types": "0.8.5",
+        "@firebase/util": "1.15.3",
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
+        "@firebase/app": "0.x",
         "@firebase/app-compat": "0.x"
       }
     },
     "node_modules/@firebase/storage-types": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
-      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.5.tgz",
+      "integrity": "sha512-GEDs5P+rNUfNcS+wxIdOLAHficife2YXtvTJnyi3ssrX11AAtBg+nDUdbYh8vuBzWehVQZPmztGUUnud4L+4yg==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
@@ -719,9 +745,9 @@
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.12.1.tgz",
-      "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.3.tgz",
+      "integrity": "sha512-c/z/gaIlaaLZEuGbE6sLUuJ61tskg1JghvhcNQzW948ASBinbVBBRnZTC4b4yt4LaEtJQkYlyzqLHcutFwEIvA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -729,13 +755,13 @@
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/webchannel-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.3.tgz",
-      "integrity": "sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz",
+      "integrity": "sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -4854,40 +4880,40 @@
       }
     },
     "node_modules/firebase": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-11.10.0.tgz",
-      "integrity": "sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w==",
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.18.0.tgz",
+      "integrity": "sha512-XaL6tlE5Xd20ZDhckqOMIw+JJTET+wTdeZPxQ7ihc42oxRb7kWUyn/j1LO5V9dH1xq8Rv5R71Pv1fBCdIkt9Rw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/ai": "1.4.1",
-        "@firebase/analytics": "0.10.17",
-        "@firebase/analytics-compat": "0.2.23",
-        "@firebase/app": "0.13.2",
-        "@firebase/app-check": "0.10.1",
-        "@firebase/app-check-compat": "0.3.26",
-        "@firebase/app-compat": "0.4.2",
-        "@firebase/app-types": "0.9.3",
-        "@firebase/auth": "1.10.8",
-        "@firebase/auth-compat": "0.5.28",
-        "@firebase/data-connect": "0.3.10",
-        "@firebase/database": "1.0.20",
-        "@firebase/database-compat": "2.0.11",
-        "@firebase/firestore": "4.8.0",
-        "@firebase/firestore-compat": "0.3.53",
-        "@firebase/functions": "0.12.9",
-        "@firebase/functions-compat": "0.3.26",
-        "@firebase/installations": "0.6.18",
-        "@firebase/installations-compat": "0.2.18",
-        "@firebase/messaging": "0.12.22",
-        "@firebase/messaging-compat": "0.2.22",
-        "@firebase/performance": "0.7.7",
-        "@firebase/performance-compat": "0.2.20",
-        "@firebase/remote-config": "0.6.5",
-        "@firebase/remote-config-compat": "0.2.18",
-        "@firebase/storage": "0.13.14",
-        "@firebase/storage-compat": "0.3.24",
-        "@firebase/util": "1.12.1"
+        "@firebase/ai": "2.15.0",
+        "@firebase/analytics": "0.10.24",
+        "@firebase/analytics-compat": "0.2.30",
+        "@firebase/app": "0.16.1",
+        "@firebase/app-check": "0.13.1",
+        "@firebase/app-check-compat": "0.4.7",
+        "@firebase/app-compat": "0.5.17",
+        "@firebase/app-types": "0.9.6",
+        "@firebase/auth": "1.13.5",
+        "@firebase/auth-compat": "0.6.10",
+        "@firebase/data-connect": "0.7.4",
+        "@firebase/database": "1.1.5",
+        "@firebase/database-compat": "2.1.7",
+        "@firebase/firestore": "4.17.1",
+        "@firebase/firestore-compat": "0.4.13",
+        "@firebase/functions": "0.14.0",
+        "@firebase/functions-compat": "0.5.0",
+        "@firebase/installations": "0.6.24",
+        "@firebase/installations-compat": "0.2.24",
+        "@firebase/messaging": "0.13.2",
+        "@firebase/messaging-compat": "0.2.29",
+        "@firebase/performance": "0.7.14",
+        "@firebase/performance-compat": "0.2.27",
+        "@firebase/remote-config": "0.9.2",
+        "@firebase/remote-config-compat": "0.2.29",
+        "@firebase/storage": "0.14.5",
+        "@firebase/storage-compat": "0.4.5",
+        "@firebase/util": "1.15.3"
       }
     },
     "node_modules/firebase-tools": {
@@ -8309,6 +8335,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/uhop"
+      }
+    },
+    "node_modules/re2js": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/re2js/-/re2js-2.8.6.tgz",
+      "integrity": "sha512-xLgQil4kIUCrAzVk9fRSkxkFNwmygLFjVxXrLc65aE1F0+Zsb8rxumFBy4XKyvgMCTL6kilDq3EZ0piE2dP/Dg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/readable-stream": {

--- a/test_rules/package.json
+++ b/test_rules/package.json
@@ -9,10 +9,10 @@
     "test:watch": "firebase emulators:exec --only firestore,storage,auth --project flutter-template-local 'vitest'"
   },
   "devDependencies": {
-    "@firebase/rules-unit-testing": "^4.0.1",
+    "@firebase/rules-unit-testing": "^5.0.2",
     "firebase-tools": "^15.28.2",
     "vitest": "^4.1.11",
-    "firebase": "^11.0.0"
+    "firebase": "^12.0.0"
   },
   "overrides": {
     "re2": "^1.26.1",


### PR DESCRIPTION
Supersedes #61.

#61 bumped `@firebase/rules-unit-testing` to 5.0.2 alone and failed `npm ci`:

```
peer firebase@"^12.0.0" from @firebase/rules-unit-testing@5.0.2
Found: firebase@11.10.0
```

v5 declares a `firebase@^12` peer, so both have to move in one change. Dependabot opens them separately and cannot know that.

**The major is the peer bump, not an API break.** The suite uses `initializeTestEnvironment` / `assertFails` / `assertSucceeds` plus `authenticatedContext`, `unauthenticatedContext`, `withSecurityRulesDisabled`, `clearFirestore`, `clearStorage`. The three functions import and are callable under v5; the five instance methods are all in v5 `.d.ts` and `RulesTestEnvironment` is structurally unchanged. `firebase/storage` `ref`, `uploadBytes`, `getBytes`, `deleteObject` import cleanly under 12.18.0.

`npm ci` is clean with 0 vulnerabilities, so the overrides added in 706e68e still hold on the newer tree.

**The `Security rules` job is the real gate here** - the emulator needs JDK 21 and I could only verify module resolution locally, not an actual rules run.